### PR TITLE
Fixes missing export when used on 22000

### DIFF
--- a/Internal.Windows.Calls/Call.cs
+++ b/Internal.Windows.Calls/Call.cs
@@ -442,7 +442,12 @@ namespace Internal.Windows.Calls
         internal void UpdateID()
         {
             uint id = ID;
-            PhoneReinitiateCallerIdLookup(ref id);
+
+            //Simone - This might need to be fixed. In 22000 this export was removed,
+            //but I don't have a way to test eventual fixes needed. This comment fixes the crash at startup. 
+
+            //PhoneReinitiateCallerIdLookup(ref id);
+
             ID = id;
         }
 

--- a/Internal.Windows.Calls/PhoneOm/Exports.cs
+++ b/Internal.Windows.Calls/PhoneOm/Exports.cs
@@ -305,8 +305,12 @@ namespace Internal.Windows.Calls.PhoneOm
         public static extern void PhoneRefreshEcbmState();
         [DllImport("PhoneOm.dll", ExactSpelling = true, PreserveSig = false)]
         public static extern void PhoneRefreshVideoCallingSetting();
-        [DllImport("PhoneOm.dll", ExactSpelling = true, PreserveSig = false)]
-        public static extern void PhoneReinitiateCallerIdLookup(ref uint callID);
+
+        //Simone - This export was removed from PhoneOm.dll in 22000
+
+        //[DllImport("PhoneOm.dll", ExactSpelling = true, PreserveSig = false)]
+        //public static extern void PhoneReinitiateCallerIdLookup(ref uint callID);
+
         [DllImport("PhoneOm.dll", ExactSpelling = true, PreserveSig = false)]
         public static extern void PhoneRejectIncoming(in uint callID);
         [DllImport("PhoneOm.dll", ExactSpelling = true, PreserveSig = false)]


### PR DESCRIPTION
Build 22000 removes an export from PhoneOm.dll